### PR TITLE
feat: Allow save dialog (`Export UART Data`) to use recent directory context

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -656,7 +656,7 @@ class MainWindow(QMainWindow):
             self.auto_clear_plot_on_header_change = False
 
     def __save_received_data_to_file__(self):
-        name = QtWidgets.QFileDialog.getSaveFileName(self, "Save file", ".", "*.txt;;*")
+        name = QFileDialog.getSaveFileName(self, caption="Save file", filter="*.txt;;*")
         if len(name) > 0 and name[0] != '':
             with open(name[0], "w") as file:
                 file.write(self.output_editor.toPlainText())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove additional directory argument (which was `"."`) so that the save file dialog uses the same directory context as the rest of the file dialogs


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using the plotter over longer periods and running multiple tests, it is nice to be able to save the files / logs to the same directory. 

The original behavior was to always open the save file dialog in the `uart_serial_plotter` directory, and if you navigated the dialog to another directory to save elsewhere that directory location context would not persist, so that the next time you wanted to save a file, you'd have to re-navigate there all over again.

However, the open file dialog had no such issue - if you opened a file from a directory, it would default to that directory the next time you tried to open a file (within the same execution of the program).

This PR fixes the save file behavior so that the directory context is now persisted when saving (and shared between save/open).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running the uart serial plotter and testing saving a file multiple times. Tested opening to ensure that it uses the same context, and tested to ensure that changing the context from the open file dialog transfers to the save file dialog as expected.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.